### PR TITLE
Schema testing ritual root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3438,6 +3438,11 @@
         "ssb-msgs": "5.2.0"
       }
     },
+    "ssb-msg-content": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-msg-content/-/ssb-msg-content-1.0.1.tgz",
+      "integrity": "sha512-M6W0Ef+jif829USmGvh6XeS4lYb/F2lgFhfEoCE/md7ESILNOGidp8frJE2uVOzSr2wVRA265tPrnVb7rYHkug=="
+    },
     "ssb-msgs": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "JSON schemas and validation for secure scuttlebutt message types for Dark Crypstal",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/**/*.test.js"
+    "test": "tape test/**/*.test.js | tap-diff"
   },
   "repository": {
     "type": "git",
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/blockades/dark-crystal-schemas#readme",
   "dependencies": {
     "is-my-json-valid": "^2.17.2",
+    "ssb-msg-content": "^1.0.1",
     "ssb-ref": "^2.11.1",
     "ssb-schema-definitions": "^1.0.0"
   },

--- a/test/fixtures/ritual.json
+++ b/test/fixtures/ritual.json
@@ -1,0 +1,9 @@
+{
+  "type": "dark-crystal/ritual",
+  "version": "1",
+  "root": "%viiJnnnXjNkfCALivEZbrDe8UndkCCCNQ/CgBOWgJLw=.sha256",
+  "quorum":2,
+  "shards":5,
+  "tool": "secrets.js@1.4.5",
+  "recps": ["@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519"]
+}

--- a/test/fixtures/root.json
+++ b/test/fixtures/root.json
@@ -1,0 +1,6 @@
+{
+  "type": "dark-crystal/root",
+  "version": "1",
+  "name": "dark crystal core",
+  "recps": ["@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519"]
+}

--- a/test/ritual.test.js
+++ b/test/ritual.test.js
@@ -1,0 +1,79 @@
+const fs = require('fs')
+const { describe } = require('tape-plus')
+
+const validator = require('is-my-json-valid')
+const schema = require('../v1/ritual/schema/ritual')
+const validate = validator(schema, { verbose: true })
+
+const { isRitual } = require('../v1/')
+
+describe('dark-crystal/ritual schema', context => {
+  let ritual
+
+  context.beforeEach(c => {
+    ritual = JSON.parse(fs.readFileSync('./test/fixtures/ritual.json', 'utf8'))
+  })
+
+  context('is valid', assert => {
+    assert.ok(validate(ritual))
+    assert.ok(isRitual(ritual))
+
+    ritual.recps.map(recp => { return { link: recp, name: 'Bobo the Clown' } })
+    assert.ok(validate(ritual))
+    assert.ok(isRitual(ritual))
+  })
+
+  context('invalid type', assert => {
+    ritual.type = 'dark-smchystal/ritual'
+    assert.notOk(validate(ritual))
+    assert.notOk(isRitual(ritual))
+
+    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.type: pattern mismatch'])
+  })
+
+  context('invalid version', assert => {
+    ritual.version = 1
+    assert.notOk(validate(ritual))
+    assert.notOk(isRitual(ritual))
+
+    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.version: is the wrong type'])
+  })
+
+  context('invalid quorum', assert => {
+    ritual.quorum = "3"
+    assert.notOk(validate(ritual))
+    assert.notOk(isRitual(ritual))
+
+    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.quorum: is the wrong type'])
+  })
+
+  context('invalid shards', assert => {
+    ritual.shards = "3"
+    assert.notOk(validate(ritual))
+    assert.notOk(isRitual(ritual))
+
+    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.shards: is the wrong type'])
+  })
+
+  context('invalid tool', assert => {
+    ritual.tool = { library: 'secrets.js' }
+    assert.notOk(validate(ritual))
+    assert.notOk(isRitual(ritual))
+
+    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.tool: is the wrong type'])
+  })
+
+  context('invalid recps', assert => {
+    ritual.recps = ['thisisnotafeedId']
+    assert.notOk(validate(ritual))
+    assert.notOk(isRitual(ritual))
+
+    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.recps: referenced schema does not match'])
+  })
+})

--- a/test/root.test.js
+++ b/test/root.test.js
@@ -1,0 +1,60 @@
+const fs = require('fs')
+const { describe } = require('tape-plus')
+const validator = require('is-my-json-valid')
+const schema = require('../v1/root/schema/root')
+const validate = validator(schema, { verbose: true })
+
+const { isRoot } = require('../v1/')
+
+describe('dark-crystal/root schema', context => {
+  let root
+
+  context.beforeEach(c => {
+    root = JSON.parse(fs.readFileSync('./test/fixtures/root.json', 'utf8'))
+  })
+
+  context('root is valid', assert => {
+    assert.ok(validate(root))
+    assert.ok(isRoot(root))
+
+    root.recps.map(recp => { return { link: recp, name: 'Bobo the Clown' } })
+    assert.ok(validate(root))
+    assert.ok(isRoot(root))
+  })
+
+  context('invalid type', assert => {
+    root.type = 'dark-smchystal/root'
+    assert.notOk(validate(root))
+    assert.notOk(isRoot(root))
+
+    var errors = root.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.type: pattern mismatch'])
+  })
+
+  context('invalid version', assert => {
+    root.version = 1
+    assert.notOk(validate(root))
+    assert.notOk(isRoot(root))
+
+    var errors = root.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.version: is the wrong type'])
+  })
+
+  context('invalid name', assert => {
+    root.name = { name: 'this is my name' }
+    assert.notOk(validate(root))
+    assert.notOk(isRoot(root))
+
+    var errors = root.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.name: is the wrong type'])
+  })
+
+  context('invalid recps', assert => {
+    root.recps = ['thisisnotafeedId']
+    assert.notOk(validate(root))
+    assert.notOk(isRoot(root))
+
+    var errors = root.errors.map(e => `${e.field}: ${e.message}`)
+    assert.deepEqual(errors, ['data.recps: referenced schema does not match'])
+  })
+})

--- a/v1/index.js
+++ b/v1/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  isRoot: require('./root/sync/isRoot'),
+  isRitual: require('./ritual/sync/isRitual')
+}

--- a/v1/ritual/schema/ritual.js
+++ b/v1/ritual/schema/ritual.js
@@ -18,16 +18,7 @@ module.exports = {
     quorum: { type: 'number' },
     shards: { type: 'number' },
     tool: { type: 'string' },
-    recps: {
-      type: 'array',
-      items: {
-        oneOf: [
-          { type: 'null' },
-          { $ref: '#/definitions/feedId' },
-          { $ref: '#/definitions/feed' }
-        ]
-      }
-    }
+    recps: { $ref: '#/definitions/recps' }
   },
   definitions: definitions
 }

--- a/v1/ritual/sync/isRitual.js
+++ b/v1/ritual/sync/isRitual.js
@@ -1,0 +1,4 @@
+const validator = require('../../lib/validator')
+const schema = require('../schema/ritual')
+
+module.exports = validator(schema)

--- a/v1/root/schema/root.js
+++ b/v1/root/schema/root.js
@@ -4,7 +4,7 @@ const SCHEMA_VERSION = 1 // require(' can you fill me innn ')
 module.exports = {
   $schema: 'http://json-schema.org/schema#',
   type: 'object',
-  required: ['type', 'version', 'name'],
+  required: ['type', 'version', 'name', 'recps'],
   properties: {
     type: {
       type: 'string',
@@ -15,16 +15,7 @@ module.exports = {
       pattern: `^${SCHEMA_VERSION}$`
     },
     name: { type: 'string' },
-    recps: {
-      type: 'array',
-      items: {
-        oneOf: [
-          { type: 'null' },
-          { $ref: '#/definitions/feedId' },
-          { $ref: '#/definitions/feed' }
-        ]
-      }
-    }
+    recps: { $ref: '#/definitions/recps' }
   },
   definitions: definitions
 }

--- a/v1/root/sync/isRoot.js
+++ b/v1/root/sync/isRoot.js
@@ -1,0 +1,4 @@
+const validator = require('../../lib/validator')
+const schema = require('../schema/root')
+
+module.exports = validator(schema)


### PR DESCRIPTION
* schema corrections made for `recps` field
* `tape-plus` with `tap-diff` for testing, makes for really neat tests with easy to use hooks. 
* use JSON fixtures for neat tests
* validator helper functions